### PR TITLE
Remove format for local spec

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,1 @@
---format documentation
 --color


### PR DESCRIPTION
I think it's better to allow other developers pick the style they like. 

I personally prefer `progress` format over `documentation`, but may be another people don't like this.

To change the rspec format, just edit the `~/.rspec` instead.
